### PR TITLE
feat: Handle JSON request bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,8 @@ version = "0.1.2"
 dependencies = [
  "axum",
  "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ axum = { version = "0.8.4", default-features = false, features = [
 ] }
 reqwest = { version = "0.12.23", features = ["rustls-tls", "json"] }
 tokio = { version = "1.47.1", features = ["net", "macros"] }
+serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.123"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
When the Content-Type header is application/json, parse the request body as JSON and use the `text` field as the message. Otherwise, use the raw request body.

This allows clients to send messages in a more structured way while maintaining backward compatibility for plain text requests.